### PR TITLE
feat: build releases with GoReleaser

### DIFF
--- a/.github/workflows/job-version-bump.yaml
+++ b/.github/workflows/job-version-bump.yaml
@@ -115,22 +115,11 @@ jobs:
     if: github.event_name == 'release'
     name: 📦 Build & Attach Binaries
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - goos: linux
-            goarch: amd64
-          - goos: linux
-            goarch: arm64
-          - goos: darwin
-            goarch: amd64
-          - goos: darwin
-            goarch: arm64
-          - goos: windows
-            goarch: amd64
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -138,22 +127,12 @@ jobs:
           go-version-file: ./go.mod
           cache: true
 
-      - name: Build Binary
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: 0
-        run: |
-          BINARY_NAME="bin/changelog-updater-action-${{ matrix.goos }}-${{ matrix.goarch }}"
-          if [ "${{ matrix.goos }}" = "windows" ]; then BINARY_NAME="${BINARY_NAME}.exe"; fi
-          go build -v \
-            -o "$BINARY_NAME" \
-            -ldflags "-s -w -X 'main.Version=${{ github.event.release.tag_name }}' -X 'main.Gitsha=${{ github.sha }}' -extldflags '-static'" \
-            ./cmd/action
-
-      - name: Upload Binary to Release
-        uses: softprops/action-gh-release@v2
+      - name: Release via GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          files: bin/*
+          args: -p 3 release --clean --timeout 60m0s
+          version: '~> v2'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_COMMIT_SHA: ${{ github.sha }}
+          CI_COMMIT_TAG: ${{ github.event.release.tag_name }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+# ISC License
+#
+# Copyright (c) 2026 Shane & Contributors
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+version: 2
+
+builds:
+  - binary: changelog-updater-action
+    main: ./cmd/action
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X 'main.Version={{ .Tag }}'
+      - -X 'main.Gitsha={{ .ShortCommit }}'
+
+archives:
+  # Raw, un-tarred binaries named to match what the Docker action's
+  # Dockerfile downloads at invocation time:
+  # changelog-updater-action-linux-amd64, etc.
+  - id: raw
+    formats:
+      - binary
+    name_template: >-
+      {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}
+  # Conventional packaged archives for direct consumers.
+  - id: archive
+    formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}-{{ .Os }}-{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  disable: true


### PR DESCRIPTION
## What and why

Migrate the release pipeline from a hand-rolled cross-compile matrix to GoReleaser, matching the pattern already shipped on golic.

- Add `.goreleaser.yaml` (v2 schema) building `./cmd/action` for linux/darwin/windows on amd64/arm64, with `-X main.Version` / `-X main.Gitsha` ldflags. Since the version vars live in `package main`, the linker's `main.*` special-case form is the correct one (verified via snapshot build + `strings`: `-X 'main.Version=v0.3.2' -X 'main.Gitsha=...'` is embedded).
- Replace the `Build_and_Release` matrix job in `job-version-bump.yaml` with a single `goreleaser/goreleaser-action@v6` step (`version: '~> v2'`, `args: -p 3 release --clean --timeout 60m0s`). The `Update_On_Main` prep job and the releasable-changes gate are untouched.

## Docker-action interaction

This is a Docker action (`using: docker`, `image: Dockerfile`). The Dockerfile downloads a raw binary named `changelog-updater-action-linux-${TARGETARCH}` from `releases/latest/download/` at action-invocation time. A plain archive-only config would have broken that.

The GoReleaser config therefore emits two archive sets: a `binary`-format archive that keeps the exact `changelog-updater-action-<os>-<arch>` raw-binary names the Dockerfile expects, plus conventional `tar.gz`/`zip` packages and a checksums file for direct consumers. Snapshot output confirms `changelog-updater-action-linux-amd64` and `changelog-updater-action-linux-arm64` are produced verbatim, so the Dockerfile and action runtime are unaffected. No change to how the Dockerfile builds or runs.

## Verification

- `go build ./...` clean
- `goreleaser check` valid
- `goreleaser release --snapshot --clean --skip=publish` builds all 6 targets, produces raw binaries + archives + checksums, version embedded
- ISC GoLic gate: `golic inject -t isc -c "2026 Shane & Contributors" -d -x` reports 0/22 changed
- `yamllint .` clean

Closes #27