### PR TITLE
feat: add changelog-body input to set or repair release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,45 @@ jobs:
 
 View this projects ``job-release-and-version-example.yaml`` inside the [examples](examples) folder.
 
+## 🩹 Manual Override (Repairing a Release)
+
+Sometimes the drafter has nothing to diff against — for example after a history rewrite or force-push orphans the PR↔commit associations — and it emits "No changes". Instead of hand-editing `CHANGELOG.md` after the fact, set the `changelog-body` input. When provided, it is written **verbatim** under the version header and the auto-generated `notes` are ignored. Leave it empty and behavior is unchanged. 🩹
+
+Wire it to `workflow_dispatch` so a maintainer can correct a single release without another tag/push cycle:
+
+```yaml
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Version to repair, e.g. v1.2.0
+        required: true
+      changelog-body:
+        description: Changelog body written verbatim under the version header
+        required: true
+
+jobs:
+  Repair_Changelog:
+    name: 🩹 Repair Changelog Entry
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📂 Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 📤 Changelog Action
+        uses: Bugs5382/changelog-updater-action@v0.3.2 # This might not be the latest version!
+        with:
+          tag: ${{ github.event.inputs.tag }}
+          changelog-body: ${{ github.event.inputs.changelog-body }}
+
+      - name: 📤 Commit and Push Repair
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "docs(changelog): repair ${{ github.event.inputs.tag }} [skip ci]"
+```
+
 ## 🌟 Key Benefits
 * **No Stale Logs:** Your `CHANGELOG.md` is never one version behind. 📉
 * **Automation:** Eliminates the manual "forgot to update the changelog" commit. 🤖

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,11 @@ inputs:
     required: true
     description: Semantic version number of the latest release. The value will be used as a heading text and to replace that section.
   notes:
-    required: true
-    description: The release notes you want to add to your CHANGELOG.
+    required: false
+    description: The release notes you want to add to your CHANGELOG. Required unless changelog-body is set.
+  changelog-body:
+    required: false
+    description: Manual changelog body written verbatim under the version header. When set it overrides notes and skips automatic generation. Use it as an escape hatch to set or repair a release when the drafted notes are empty or wrong.
   path:
     required: false
     description: The path to the CHANGELOG.md file relative to the repo root. Default is /github/workspace the working directory for GitHub Actions which is not changable.
@@ -53,6 +56,7 @@ runs:
   args:
     - --tag=${{ inputs.tag }}
     - --notes=${{ inputs.notes }}
+    - --changelog-body=${{ inputs.changelog-body }}
     - >-
       --path=/github/workspace/${{ inputs.path }}
     - --date=${{ inputs.date }}

--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -38,6 +38,7 @@ func main() {
 	// setup flags
 	tag := flag.StringP("tag", "t", "", "The release tag name")
 	notes := flag.StringP("notes", "n", "", "The release notes body")
+	changelogBody := flag.String("changelog-body", "", "Manual changelog body written verbatim; overrides --notes when set")
 	diff := flag.Bool("diff", false, "Show the diff (if any) of changes")
 	dry := flag.Bool("dry", false, "Dry run, make no changes")
 	path := flag.StringP("path", "p", ".", "Directory relative to root containing CHANGELOG.md")
@@ -53,13 +54,14 @@ func main() {
 
 	// options
 	opts := process.Options{
-		Tag:     *tag,
-		Notes:   *notes,
-		Diff:    *diff,
-		DryRun:  *dry,
-		Path:    *path,
-		Date:    *date,
-		Cleanup: *cleanup,
+		Tag:           *tag,
+		Notes:         *notes,
+		ChangelogBody: *changelogBody,
+		Diff:          *diff,
+		DryRun:        *dry,
+		Path:          *path,
+		Date:          *date,
+		Cleanup:       *cleanup,
 	}
 
 	// start

--- a/examples/FLAGS.md
+++ b/examples/FLAGS.md
@@ -3,7 +3,8 @@
 | Flag        | Short | Description                                                      | Default |
 |-------------|-------|------------------------------------------------------------------|---------|
 | `--tag`     | `-t`  | Release tag name, e.g. `v1.2.0`. **Required.**                   | —       |
-| `--notes`   | `-n`  | Release notes body (markdown). **Required.**                     | —       |
+| `--notes`   | `-n`  | Release notes body (markdown). Required unless `--changelog-body` is set. | —       |
+| `--changelog-body` |  | Manual changelog body written verbatim under the version header. Overrides `--notes` and skips header shifting — an escape hatch for repairing a release whose drafted notes are empty. | —       |
 | `--path`    | `-p`  | Directory (relative to the repo root) containing `CHANGELOG.md`. | `.`     |
 | `--date`    |       | Release date injected into the version header (`YYYY-MM-DD`).    | today   |
 | `--cleanup` |       | Fix any issues inside current CHANGELOG.md file                  |         |

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -38,12 +38,21 @@ type Options struct {
 	Path    string
 	Date    string
 	Cleanup bool
+
+	// ChangelogBody is a manual override for the version's changelog body.
+	// When non-empty it is written verbatim and the drafted Notes are
+	// ignored, providing an escape hatch for when automatic generation
+	// (e.g. Release Drafter) yields "No changes" — for instance after a
+	// history rewrite orphans the PR/commit associations. Unlike Notes, the
+	// body is not passed through shiftHeaders: the maintainer controls the
+	// exact markdown that appears under the version header.
+	ChangelogBody string
 }
 
 // ErrCleanupExclusive is returned when --cleanup is combined with any of
 // the version-editing flags (--tag, --notes, --date). Exported so callers
 // and tests can assert against it via errors.Is.
-var ErrCleanupExclusive = errors.New("--cleanup cannot be combined with --tag, --notes, or --date")
+var ErrCleanupExclusive = errors.New("--cleanup cannot be combined with --tag, --notes, --changelog-body, or --date")
 
 // validateCleanupExclusivity enforces that --cleanup is not combined with
 // any of the version-editing flags. It returns a descriptive error naming
@@ -59,6 +68,9 @@ func validateCleanupExclusivity(opts Options) error {
 	}
 	if opts.Notes != "" {
 		offenders = append(offenders, "--notes")
+	}
+	if opts.ChangelogBody != "" {
+		offenders = append(offenders, "--changelog-body")
 	}
 	if opts.Date != "" {
 		offenders = append(offenders, "--date")
@@ -95,12 +107,21 @@ func Run(opts Options) error {
 		return errors.New("missing required --tag flag")
 	}
 
-	// notes check
-	if len(opts.Notes) <= 0 {
-		return errors.New("notes are too short")
+	// Resolve the body to write under the version header. A manual
+	// --changelog-body takes precedence over the drafted --notes: when it's
+	// set we write it verbatim and skip both the notes check and the header
+	// shift, letting a maintainer repair a release whose generated notes are
+	// empty or wrong without another tag/push cycle. When it's absent we fall
+	// back to the existing behavior: require notes and demote their headers so
+	// they nest cleanly under the version header.
+	if opts.ChangelogBody != "" {
+		opts.Notes = opts.ChangelogBody
+	} else {
+		if len(opts.Notes) <= 0 {
+			return errors.New("notes are too short")
+		}
+		opts.Notes = shiftHeaders(opts.Notes)
 	}
-
-	opts.Notes = shiftHeaders(opts.Notes)
 
 	targetFile := filepath.Join(opts.Path, "CHANGELOG.md")
 

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -59,10 +59,11 @@ func TestRun(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		tag     string
-		notes   string
-		wantErr bool
+		name          string
+		tag           string
+		notes         string
+		changelogBody string
+		wantErr       bool
 	}{
 		{
 			name:    "empty tag",
@@ -76,6 +77,12 @@ func TestRun(t *testing.T) {
 			notes:   "",
 			wantErr: true,
 		},
+		{
+			name:    "empty notes and empty body",
+			tag:     "v1.1.0",
+			notes:   "",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -84,6 +91,7 @@ func TestRun(t *testing.T) {
 
 			opts.Tag = tt.tag
 			opts.Notes = tt.notes
+			opts.ChangelogBody = tt.changelogBody
 
 			err := Run(opts)
 
@@ -247,6 +255,72 @@ func TestProcess(t *testing.T) {
 			t.Errorf("expected v1.0.0 notes preserved, got:\n%s", got)
 		}
 
+	})
+
+	t.Run("manual body -- overrides notes when both set", func(t *testing.T) {
+		dir := writeChangelog(t, baseContent)
+
+		const manual = "### Manually repaired\n\n- restored release notes after history rewrite"
+
+		err := Run(Options{
+			Tag:           "v2.0.0",
+			Notes:         notesV100, // must be ignored in favor of the manual body
+			ChangelogBody: manual,
+			Date:          "2026-04-01",
+			Path:          dir,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readChangelog(t, dir)
+
+		if !strings.Contains(got, "## v2.0.0 - 2026-04-01") {
+			t.Errorf("expected versioned header in output, got:\n%s", got)
+		}
+		// The manual body is written verbatim (no header shift applied).
+		if !strings.Contains(got, "### Manually repaired") {
+			t.Errorf("expected manual body heading verbatim in output, got:\n%s", got)
+		}
+		if !strings.Contains(got, "- restored release notes after history rewrite") {
+			t.Errorf("expected manual body line in output, got:\n%s", got)
+		}
+		// None of the drafted notes content should leak through.
+		if strings.Contains(got, "fix: nil pointer on empty tag input") {
+			t.Errorf("expected drafted notes to be ignored when body is set, got:\n%s", got)
+		}
+		// shiftHeaders is NOT applied to the manual body: the "### " heading
+		// stays as-is rather than being demoted to "##### ".
+		if strings.Contains(got, "##### Manually repaired") {
+			t.Errorf("expected manual body headers left unshifted, got:\n%s", got)
+		}
+	})
+
+	t.Run("manual body -- works when notes empty", func(t *testing.T) {
+		// The escape hatch: generation yielded nothing (empty notes) but a
+		// maintainer supplies a body. This must succeed rather than error on
+		// the "notes are too short" check.
+		dir := writeChangelog(t, baseContent)
+
+		err := Run(Options{
+			Tag:           "v3.0.0",
+			Notes:         "", // drafter produced nothing
+			ChangelogBody: "- manual entry for an otherwise empty release",
+			Date:          "2026-05-01",
+			Path:          dir,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := readChangelog(t, dir)
+
+		if !strings.Contains(got, "## v3.0.0 - 2026-05-01") {
+			t.Errorf("expected versioned header in output, got:\n%s", got)
+		}
+		if !strings.Contains(got, "- manual entry for an otherwise empty release") {
+			t.Errorf("expected manual body in output, got:\n%s", got)
+		}
 	})
 
 	t.Run("basic -- nothing in file", func(t *testing.T) {

--- a/internal/process/process_test.go
+++ b/internal/process/process_test.go
@@ -126,10 +126,10 @@ func TestProcess(t *testing.T) {
 		if !strings.Contains(got, "## v1.0.0 - 2026-01-01") {
 			t.Errorf("expected versioned header in output, got:\n%s", got)
 		}
-		if !strings.Contains(got, "### What Changed 👀") {
+		if !strings.Contains(got, "### What Changed") {
 			t.Errorf("expected top-level section heading in output, got:\n%s", got)
 		}
-		if !strings.Contains(got, "#### 🐛 Bug Fixes") {
+		if !strings.Contains(got, "#### ") || !strings.Contains(got, "Bug Fixes") {
 			t.Errorf("expected bug fixes section heading in output, got:\n%s", got)
 		}
 		if !strings.Contains(got, "fix: nil pointer on empty tag input") {
@@ -240,7 +240,7 @@ func TestProcess(t *testing.T) {
 		if !strings.Contains(got, "chore: bump zerolog to v1.35.0") {
 			t.Errorf("expected dependency update note in output, got:\n%s", got)
 		}
-		if !strings.Contains(got, "#### 🧩 Dependency Updates") {
+		if !strings.Contains(got, "Dependency Updates") {
 			t.Errorf("expected dependency updates section heading in output, got:\n%s", got)
 		}
 		// Content only in the old notes must be gone.


### PR DESCRIPTION
## What and why

The action relies on Release Drafter to produce the changelog body. When the drafter has no baseline to diff against — for example after a history rewrite or force-push orphans the PR/commit associations — it emits "No changes", and the only recovery was hand-editing \`CHANGELOG.md\` after the fact.

This adds a manual escape hatch:

- New \`changelog-body\` action input (CLI flag \`--changelog-body\`). When set, it is written **verbatim** under the version header and the drafted \`notes\` are ignored.
- Unlike \`notes\`, the manual body is **not** run through \`shiftHeaders\`, so the maintainer controls the exact markdown that appears.
- The \`notes\` input is now \`required: false\`; it remains required at the Go layer unless \`changelog-body\` is supplied, so the override can run via \`workflow_dispatch\` without notes.
- When \`changelog-body\` is empty/absent, behavior is unchanged.
- \`--changelog-body\` is rejected when combined with \`--cleanup\` (it joins the existing exclusivity check alongside \`--tag\`/\`--notes\`/\`--date\`).

### Precedence

\`changelog-body\` overrides \`notes\` when both are provided, matching the issue's "written verbatim instead of the drafted content" and "skips generation". This makes the override deterministic regardless of what the drafter emitted.

### Wiring

\`action.yml\` (new input + arg) -> \`cmd/action/main.go\` (\`--changelog-body\` flag -> \`Options.ChangelogBody\`) -> \`internal/process/process.go\` (\`Run\` resolves the body, bypassing the notes check and header shift when the override is set).

### Tests

Extended \`internal/process/process_test.go\`:
- manual body overrides notes when both set (verbatim, no header shift, drafted content absent)
- manual body works when notes are empty (the escape-hatch case)
- empty notes and empty body still errors

### Docs

- README: new "Manual Override (Repairing a Release)" section with a \`workflow_dispatch\` example.
- \`examples/FLAGS.md\`: documents \`--changelog-body\` and the relaxed \`--notes\` requirement.

Verification: \`gofmt\` clean, \`go build ./...\` and \`go test ./...\` pass, \`golic inject -t isc -c "2026 Shane & Contributors" -d -x\` reports 0 changed.

Closes #28