### PR TITLE
fix: build the action binary from source in the Dockerfile

### DIFF
--- a/.github/workflows/job-docker-build.yaml
+++ b/.github/workflows/job-docker-build.yaml
@@ -13,19 +13,25 @@
 # WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-# Build the binary from the source in this checkout so the action always runs
-# the code it ships with. Previously the image downloaded the latest *released*
-# binary, which skewed against action.yml whenever a new flag (e.g.
-# --changelog-body) was added on main before a release shipped it.
-FROM golang:1.26-alpine AS build
-WORKDIR /src
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o /usr/local/bin/changelog-updater-action ./cmd/action
-
-FROM alpine:3.20
-RUN apk --no-cache add ca-certificates
-COPY --from=build /usr/local/bin/changelog-updater-action /usr/local/bin/changelog-updater-action
-ENTRYPOINT ["/usr/local/bin/changelog-updater-action"]
+name: Docker Build
+# The action runs as a Docker container action (action.yml -> Dockerfile), but
+# nothing else in CI builds that image, so a broken Dockerfile only surfaces when
+# the action is actually invoked (e.g. the Release Manager's dogfooded `uses: ./`).
+# Build the image here so Dockerfile regressions fail the PR instead.
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    branches:
+      - main
+permissions:
+  contents: read
+jobs:
+  docker:
+    name: Action image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the action image
+        run: docker build -t changelog-updater-action:ci .


### PR DESCRIPTION
## What and why

The Release Manager's dogfooded `Run Changelog Action` step (`uses: ./`) fails with `unknown flag: --changelog-body`: the Dockerfile downloads the last *released* binary (v0.3.2), but #33 added `--changelog-body` to `action.yml` on main. Deadlock — publishing the new binary needs this step.

## Changes

- Multi-stage Dockerfile that **builds the binary from the checked-out source**, so the action always runs the code it ships with (no flag/version skew, ever).
- New `Docker Build` CI job — builds the image so a broken Dockerfile fails the PR (nothing in CI built it before, which is why this slipped through).

## Notes

Docker is unavailable on my box, so the image build is validated by the new CI job rather than locally. This is independent of the open GoReleaser PR (#32), which still ships downloadable binaries for direct CLI users; the action just no longer depends on them.

Closes #34