### PR TITLE
chore: drop ci entry from v0.1.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@
 
 #### 🚀 Features
 
-- ci: fix job @Bugs5382 (#7. #9, #8, #10)
 - feat: v0.1.0 @Bugs5382 (#3)
 
 ### Extra


### PR DESCRIPTION
## What and why

The v0.1.0 `ci: fix job` entry was a CI change listed under Features; it should have been `skip-changelog`. The PRs are relabeled and this removes the entry from CHANGELOG.md. The published v0.1.0 body will be corrected separately.

Closes #36

## Verification

- [x] v0.1.0 Features now lists only the genuine feature

## How this was verified

Reviewed the v0.1.0 section after the edit.